### PR TITLE
Setup Articy classes to be found by AssetManager

### DIFF
--- a/Source/ArticyRuntime/Public/ArticyDatabase.h
+++ b/Source/ArticyRuntime/Public/ArticyDatabase.h
@@ -129,6 +129,8 @@ class ARTICYRUNTIME_API UArticyDatabase : public UDataAsset, public IShadowState
 
 public:
 
+	virtual FPrimaryAssetId GetPrimaryAssetId() const override { return FPrimaryAssetId(FName(TEXT("ArticyDatabase")), GetFName()); }
+
 	void Init();
 
 	/** Get the static instance of the database. */

--- a/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
+++ b/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
@@ -419,6 +419,8 @@ class ARTICYRUNTIME_API UArticyGlobalVariables : public UDataAsset, public IShad
 
 public:
 
+	virtual FPrimaryAssetId GetPrimaryAssetId() const override { return FPrimaryAssetId(FName(TEXT("ArticyGlobalVariables")), GetFName()); }
+
 	/**
 	 * Get a reference to the ArticyGlobalVariables asset.
 	 * Creates a temporary copy if the 

--- a/Source/ArticyRuntime/Public/ArticyPackage.h
+++ b/Source/ArticyRuntime/Public/ArticyPackage.h
@@ -23,6 +23,8 @@ protected:
 	TMap<FArticyId, TSoftObjectPtr<UArticyObject>> AssetsById;
 public: 
 
+	virtual FPrimaryAssetId GetPrimaryAssetId() const override { return FPrimaryAssetId(FName(TEXT("ArticyPackage")), GetFName()); }
+
 	void AddAsset(UArticyObject* ArticyObject);
 
 	UFUNCTION()


### PR DESCRIPTION
Override GetPrimaryAssetID in ArticyDatabase, ArticyGlobalVariables, and ArticyPackage so that they can be referenced by the AssetManager. This solves Articy not properly working in Standalone due do Articy assets not being found by the asset manager.

Solves this issue https://github.com/ArticySoftware/Articy3ImporterForUnreal/issues/65