### PR TITLE
UE 5.3 Compatibility

### DIFF
--- a/Source/ArticyEditor/Private/Customizations/ArticyGVEditor.cpp
+++ b/Source/ArticyEditor/Private/Customizations/ArticyGVEditor.cpp
@@ -59,10 +59,6 @@ void FArticyGVEditor::InitArticyGVEditor(const EToolkitMode::Type Mode, const TS
 	FAssetEditorToolkit::InitAssetEditor(Mode, InitToolkitHost, TEXT("ArticyExtensionEditor"), StandaloneDefaultLayout, bCreateDefaultStandaloneMenu, bCreateDefaultToolbar, GlobalVariables.Get(), false);
 }
 
-void FArticyGVEditor::AddReferencedObjects(FReferenceCollector& Collector)
-{
-}
-
 FLinearColor FArticyGVEditor::GetWorldCentricTabColorScale() const
 {
 	return FLinearColor(0.3f, 0.2f, 0.5f, 0.5f);

--- a/Source/ArticyEditor/Public/Customizations/ArticyGVEditor.h
+++ b/Source/ArticyEditor/Public/Customizations/ArticyGVEditor.h
@@ -2,21 +2,18 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/GCObject.h"
 #include "Toolkits/AssetEditorToolkit.h"
 #include "Misc/NotifyHook.h"
 #include "EditorUndoClient.h"
 #include "ArticyGlobalVariables.h"
 #include "Slate/GV/SArticyGlobalVariables.h"
 
-class FArticyGVEditor : public FAssetEditorToolkit, FEditorUndoClient, FNotifyHook, FGCObject
+class FArticyGVEditor : public FAssetEditorToolkit, FEditorUndoClient, FNotifyHook
 {
 public:
 	virtual ~FArticyGVEditor();
 	void InitArticyGVEditor(const EToolkitMode::Type Mode, const TSharedPtr<IToolkitHost>& InitToolkitHost, UArticyGlobalVariables* ObjectToEdit);
 
-	/** FGCObject Interface */
-	virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
 	/** IToolkit Interface */
 	virtual FLinearColor GetWorldCentricTabColorScale() const override;
 	/** FAssetEditorToolkit Interface */


### PR DESCRIPTION
I've stripped out incompatible interface to allow UE 5.3.X to compile. I'm unclear on the purpose of FGCObject seeing as FArticyGVEditor::AddReferencedObjects() implementation was empty.

I doubt overall that this is a good fix, but figured I'd get the ball rolling on UE 5.3 compatibility.