### PR TITLE
Fix literal string issues on UE 5.3

### DIFF
--- a/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
+++ b/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
@@ -324,6 +324,11 @@ public:
 		else
 			return Value = NewValue.GetString();
 	}
+
+	bool operator ==(const FString& text) const { return Value.Equals(text); }
+	bool operator !=(const FString& text) const { return !this->operator==(text); }
+	bool operator ==(const FString&& text) const { return Value.Equals(text); }
+	bool operator !=(const FString&& text) const { return !this->operator==(text); }
 	bool operator ==(const char* const text) const { return Value.Equals(text); }
 	bool operator !=(const char* const text) const { return !this->operator==(text); }
 


### PR DESCRIPTION
In UE 5.3, the comparison between a string literal and an `FString` is not caught by the `const char* const text` parameter, so we explicitly add `FString` overloads.