### PR TITLE
Missing arithmetic operators can cause compile errors in generated code

### DIFF
--- a/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
+++ b/Source/ArticyRuntime/Public/ArticyGlobalVariables.h
@@ -256,6 +256,20 @@ private:
 	TArray<ArticyShadowState<int>> Shadows;
 };
 
+// interim, hopefully
+static int operator+(const UArticyInt& v1, const UArticyInt& v2)
+{
+	return v1.Get() + v2.Get();
+}
+static int operator+(int k, const UArticyInt& v)
+{
+	return k + v.Get();
+}
+static int operator+(const UArticyInt& v, int k)
+{
+	return v.Get() + k;
+}
+
 //---------------------------------------------------------------------------//
 
 UCLASS(BlueprintType)


### PR DESCRIPTION
Note: this is a demonstrative code snippet and is not intended to be integrated directly.

My writer has produced a condition block which will cause the importer to generate invalid code:
![image](https://github.com/ArticySoftware/Articy3ImporterForUnreal/assets/4526254/e391ef64-2055-41a0-b87f-2872cb81b9b4)

The generated code in `XYZExpressoScripts.h` is a fairly direct transliteration of the text in articy:draft:
```
Conditions.Add(-1162260831, [&]
{
	return ConditionOrTrue(
		(*Confrontations->Apologetic) < ((*Confrontations->Defensive) + (*Confrontations->Mending))
	);
});
```
This fails to compile because the only available operators for UArticyInt that relate to addition are `+=`. My provided methods provide:
  1. an implementation of `A + B` which fixes my immediate compile error.
  2. implementations which may fix more complex compound variants of this issue. eg: `A < B + ((C + D) + E)`

A full fix in this manner would provide methods for all other operators `-`, `*`, `/`, etc. as appropriate. For brevity's sake I have omitted them.

Am I on the right track? Have I missed something crucial in understanding why the code generated was invalid, or was this a simple untested case?